### PR TITLE
Stale build instructions fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ```bash
 git clone https://github.com/OpenMaxIO/openmaxio-object-browser 
 cd openmaxio-object-browser/web-app
-git checkout v1.7.6
 yarn install 
 yarn build 
 cd ../


### PR DESCRIPTION
Everything builds just fine as long as you don't checkout web-app v1.7.6 like the readme instructs you to; which points to a deleted repo, and using the code as-is builds fine.